### PR TITLE
fix: add -n flag for entr non-interactive mode

### DIFF
--- a/simple/glitch.dockerfile
+++ b/simple/glitch.dockerfile
@@ -5,5 +5,5 @@ COPY vendor vendor
 COPY render/api render/api
 COPY go.mod ./
 COPY glitch glitch
-CMD ls glitch/*.go | entr -r ./glitch/re-build.sh
+CMD ls glitch/*.go | entr -n -r ./glitch/re-build.sh
 # CMD ./glitch/re-build.sh

--- a/simple/muxer.dockerfile
+++ b/simple/muxer.dockerfile
@@ -7,4 +7,4 @@ COPY storage/client storage/client
 COPY storage/api storage/api
 COPY go.mod ./
 COPY muxer muxer
-CMD ls muxer/*.go | entr -r ./muxer/re-build.sh
+CMD ls muxer/*.go | entr -n -r ./muxer/re-build.sh

--- a/simple/rectangler.dockerfile
+++ b/simple/rectangler.dockerfile
@@ -5,4 +5,4 @@ COPY vendor vendor
 COPY render/api render/api
 COPY go.mod ./
 COPY rectangler rectangler
-CMD ls rectangler/*.go | entr -r ./rectangler/re-build.sh
+CMD ls rectangler/*.go | entr -n -r ./rectangler/re-build.sh

--- a/simple/red.dockerfile
+++ b/simple/red.dockerfile
@@ -5,4 +5,4 @@ COPY vendor vendor
 COPY render/api render/api
 COPY go.mod ./
 COPY red red
-CMD ls red/*.go | entr -r ./red/re-build.sh
+CMD ls red/*.go | entr -n -r ./red/re-build.sh

--- a/simple/storage.dockerfile
+++ b/simple/storage.dockerfile
@@ -4,4 +4,4 @@ RUN apk add entr
 COPY vendor vendor
 COPY go.mod ./
 COPY storage storage
-CMD ls storage/*.go | entr -r ./storage/re-build.sh
+CMD ls storage/*.go | entr -n -r ./storage/re-build.sh


### PR DESCRIPTION
### Background
Various resources in `pixeltilt/simple` use the latest `golang:alpine` version. As of June 15th, this is now Alpine 3.14, which has `entr` v4.9 in its [package list](https://pkgs.alpinelinux.org/packages?name=entr&branch=v3.14). Unfortunately, as of v4.9, `entr` [raises an error](https://github.com/eradman/entr/blob/master/NEWS#L14) if terminal attributes can't be read, meaning that the user must now pass the `-n` flag to use `entr` in non-interactive mode. 

### Changes
This PR adds the `-n` flag in the dockerfiles for `pixeltilt/simple`.